### PR TITLE
Fix minor issues and enable duty cycle by default

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -36,10 +36,12 @@ panel serve dashboard.py --show
 
 ## Duty cycle
 
-Un gestionnaire de duty cycle simple est disponible via `duty_cycle.py`. Vous
-pouvez l'activer dans `Simulator` en passant le paramètre `duty_cycle` (par
-exemple `0.01` pour 1 %). Les transmissions seront automatiquement retardées
-afin de respecter cette contrainte.
+Le simulateur applique par défaut un duty cycle de 1 % pour se rapprocher des
+contraintes LoRa réelles. Le gestionnaire de duty cycle situé dans
+`duty_cycle.py` peut être configuré en passant un autre paramètre `duty_cycle`
+à `Simulator` (par exemple `0.02` pour 2 %). Transmettre `None` désactive ce
+mécanisme. Les transmissions sont automatiquement retardées pour respecter ce
+pourcentage.
 
 ## Mobilité optionnelle
 

--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -17,7 +17,6 @@ if ROOT_DIR not in sys.path:
 from launcher.simulator import Simulator
 import numpy as np
 import time
-import os
 
 # --- Initialisation Panel ---
 pn.extension('plotly')

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -22,7 +22,7 @@ class Simulator:
     def __init__(self, num_nodes: int = 10, num_gateways: int = 1, area_size: float = 1000.0,
                  transmission_mode: str = 'Random', packet_interval: float = 60.0,
                  packets_to_send: int = 0, adr_node: bool = False, adr_server: bool = False,
-                 duty_cycle: float | None = None, mobility: bool = True):
+                 duty_cycle: float | None = 0.01, mobility: bool = True):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
         :param num_nodes: Nombre de nœuds à simuler.
@@ -33,8 +33,8 @@ class Simulator:
         :param packets_to_send: Nombre total de paquets à émettre avant d'arrêter la simulation (0 = infini).
         :param adr_node: Activation de l'ADR côté nœud.
         :param adr_server: Activation de l'ADR côté serveur.
-        :param duty_cycle: Facteur de duty cycle (ex: 0.01 pour 1 %). Si None,
-            le duty cycle est désactivé.
+        :param duty_cycle: Facteur de duty cycle (ex: 0.01 pour 1 %). Par
+            défaut à 0.01. Si None, le duty cycle est désactivé.
         :param mobility: Active la mobilité aléatoire des nœuds lorsqu'il est
             à True.
         """
@@ -50,7 +50,7 @@ class Simulator:
         # Activation ou non de la mobilité des nœuds
         self.mobility_enabled = mobility
 
-        # Gestion du duty cycle
+        # Gestion du duty cycle (activé par défaut à 1 %)
         self.duty_cycle_manager = DutyCycleManager(duty_cycle) if duty_cycle else None
         
         # Initialiser le canal radio et le serveur réseau


### PR DESCRIPTION
## Summary
- remove duplicate import in dashboard
- activate duty cycle at 1% by default in simulator
- document new behaviour in README

## Testing
- `python -m py_compile VERSION_3/launcher/*.py VERSION_3/run.py`

------
https://chatgpt.com/codex/tasks/task_e_6850b74833a483319ce729a5f882975f