### PR TITLE
Enable multi-channel transmissions

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -50,3 +50,11 @@ création du `Simulator` grâce au paramètre `mobility` (booléen). Dans le
 `dashboard`, cette option correspond à la case « Activer la mobilité des
 nœuds ». Si elle est décochée, les positions des nœuds restent fixes pendant
 la simulation.
+
+## Multi-canaux
+
+Le simulateur permet d'utiliser plusieurs canaux radio. Passez une instance
+`MultiChannel` ou une liste de fréquences à `Simulator` via les paramètres
+`channels` et `channel_distribution`. Dans le `dashboard`, réglez **Nb
+sous-canaux** et **Répartition canaux** pour tester un partage Round‑robin ou
+aléatoire des fréquences entre les nœuds.

--- a/VERSION_3/launcher/__init__.py
+++ b/VERSION_3/launcher/__init__.py
@@ -2,6 +2,7 @@
 from .node import Node
 from .gateway import Gateway
 from .channel import Channel
+from .multichannel import MultiChannel
 from .server import NetworkServer
 from .simulator import Simulator
 from .duty_cycle import DutyCycleManager

--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -41,6 +41,10 @@ packets_input = pn.widgets.IntInput(name="Nombre de paquets (0=infin)", value=0,
 adr_node_checkbox = pn.widgets.Checkbox(name="ADR nœud", value=False)
 adr_server_checkbox = pn.widgets.Checkbox(name="ADR serveur", value=False)
 
+# --- Multi-canaux ---
+num_channels_input = pn.widgets.IntInput(name="Nb sous-canaux", value=1, step=1, start=1)
+channel_dist_select = pn.widgets.RadioButtonGroup(name="Répartition canaux", options=['Round-robin', 'Aléatoire'], value='Round-robin')
+
 # --- Widget pour activer/désactiver la mobilité des nœuds ---
 mobility_checkbox = pn.widgets.Checkbox(name="Activer la mobilité des nœuds", value=False)
 
@@ -185,7 +189,9 @@ def on_start(event):
         packets_to_send=int(packets_input.value),
         adr_node=adr_node_checkbox.value,
         adr_server=adr_server_checkbox.value,
-        mobility=mobility_checkbox.value
+        mobility=mobility_checkbox.value,
+        channels=[868e6 + i * 200e3 for i in range(num_channels_input.value)],
+        channel_distribution='random' if channel_dist_select.value == 'Aléatoire' else 'round-robin'
     )
 
     if mobility_checkbox.value:
@@ -212,6 +218,8 @@ def on_start(event):
     packets_input.disabled = True
     adr_node_checkbox.disabled = True
     adr_server_checkbox.disabled = True
+    num_channels_input.disabled = True
+    channel_dist_select.disabled = True
     mobility_checkbox.disabled = True
     start_button.disabled = True
     stop_button.disabled = False
@@ -246,6 +254,8 @@ def on_stop(event):
     packets_input.disabled = False
     adr_node_checkbox.disabled = False
     adr_server_checkbox.disabled = False
+    num_channels_input.disabled = False
+    channel_dist_select.disabled = False
     mobility_checkbox.disabled = False
     start_button.disabled = False
     stop_button.disabled = True
@@ -302,7 +312,9 @@ stop_button.on_click(on_stop)
 # --- Mise en page du dashboard ---
 controls = pn.WidgetBox(
     num_nodes_input, num_gateways_input, area_input, mode_select, interval_input, packets_input,
-    adr_node_checkbox, adr_server_checkbox, mobility_checkbox,
+    adr_node_checkbox, adr_server_checkbox,
+    num_channels_input, channel_dist_select,
+    mobility_checkbox,
     pn.Row(start_button, stop_button, export_button),  # Ajout du bouton export ici
     export_message  # Message d'état export
 )

--- a/VERSION_3/launcher/multichannel.py
+++ b/VERSION_3/launcher/multichannel.py
@@ -1,0 +1,29 @@
+import random
+from typing import List, Sequence
+
+from .channel import Channel
+
+
+class MultiChannel:
+    """Manage several Channel objects and assign them to nodes."""
+
+    def __init__(self, channels: Sequence[Channel | float], method: str = "round-robin"):
+        if not channels:
+            raise ValueError("channels list must not be empty")
+        self.channels: List[Channel] = []
+        for ch in channels:
+            if isinstance(ch, Channel):
+                self.channels.append(ch)
+            else:
+                self.channels.append(Channel(frequency_hz=float(ch)))
+        self.method = method.lower()
+        self._rr_index = 0
+
+    def select(self) -> Channel:
+        """Return a channel according to the distribution method."""
+        if self.method == "random":
+            return random.choice(self.channels)
+        # default round robin
+        ch = self.channels[self._rr_index % len(self.channels)]
+        self._rr_index += 1
+        return ch

--- a/VERSION_3/launcher/node.py
+++ b/VERSION_3/launcher/node.py
@@ -21,7 +21,7 @@ class Node:
         last_move_time (float) : Dernier instant (s) où la position a été mise à jour (mobilité).
     """
 
-    def __init__(self, node_id: int, x: float, y: float, sf: int, tx_power: float):
+    def __init__(self, node_id: int, x: float, y: float, sf: int, tx_power: float, channel=None):
         """
         Initialise le nœud avec ses paramètres de départ.
         
@@ -41,6 +41,8 @@ class Node:
         self.sf = sf
         self.initial_tx_power = tx_power
         self.tx_power = tx_power
+        # Canal radio attribué (peut être modifié par le simulateur)
+        self.channel = channel
         
         # Énergie et compteurs de paquets
         self.energy_consumed = 0.0


### PR DESCRIPTION
## Summary
- create `MultiChannel` class to manage multiple channels
- let `Simulator` assign each node a channel and use it for RSSI and airtime
- expose multi-channel settings in the dashboard
- document how to use multiple channels

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850bacafa28833187d6a8e15a0ebe96