### PR TITLE
Add mobility speed controls to dashboard

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -55,6 +55,8 @@ des trajectoires lissées par interpolation de Bézier. La vitesse des nœuds es
 tirée aléatoirement dans la plage spécifiée (par défaut 2 à 5 m/s) et peut être
 modifiée via le paramètre `mobility_speed` du `Simulator`. Les mouvements sont
 donc continus et sans téléportation.
+Deux champs « Vitesse min » et « Vitesse max » sont disponibles dans le
+`dashboard` pour définir cette plage avant de lancer la simulation.
 
 ## Multi-canaux
 

--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -47,6 +47,14 @@ channel_dist_select = pn.widgets.RadioButtonGroup(name="Répartition canaux", op
 # --- Widget pour activer/désactiver la mobilité des nœuds ---
 mobility_checkbox = pn.widgets.Checkbox(name="Activer la mobilité des nœuds", value=False)
 
+# Widgets pour régler la vitesse minimale et maximale des nœuds mobiles
+mobility_speed_min_input = pn.widgets.FloatInput(
+    name="Vitesse min (m/s)", value=2.0, step=0.5, start=0.1
+)
+mobility_speed_max_input = pn.widgets.FloatInput(
+    name="Vitesse max (m/s)", value=5.0, step=0.5, start=0.1
+)
+
 # --- Boutons de contrôle ---
 start_button = pn.widgets.Button(name="Lancer la simulation", button_type="success")
 stop_button = pn.widgets.Button(name="Arrêter la simulation", button_type="warning", disabled=True)
@@ -158,6 +166,7 @@ def on_start(event):
         adr_node=adr_node_checkbox.value,
         adr_server=adr_server_checkbox.value,
         mobility=mobility_checkbox.value,
+        mobility_speed=(float(mobility_speed_min_input.value), float(mobility_speed_max_input.value)),
         channels=[868e6 + i * 200e3 for i in range(num_channels_input.value)],
         channel_distribution='random' if channel_dist_select.value == 'Aléatoire' else 'round-robin'
     )
@@ -187,6 +196,8 @@ def on_start(event):
     num_channels_input.disabled = True
     channel_dist_select.disabled = True
     mobility_checkbox.disabled = True
+    mobility_speed_min_input.disabled = True
+    mobility_speed_max_input.disabled = True
     start_button.disabled = True
     stop_button.disabled = False
     export_button.disabled = True
@@ -220,6 +231,8 @@ def on_stop(event):
     num_channels_input.disabled = False
     channel_dist_select.disabled = False
     mobility_checkbox.disabled = False
+    mobility_speed_min_input.disabled = False
+    mobility_speed_max_input.disabled = False
     start_button.disabled = False
     stop_button.disabled = True
     export_button.disabled = False
@@ -274,6 +287,7 @@ controls = pn.WidgetBox(
     adr_node_checkbox, adr_server_checkbox,
     num_channels_input, channel_dist_select,
     mobility_checkbox,
+    mobility_speed_min_input, mobility_speed_max_input,
     pn.Row(start_button, stop_button, export_button),  # Ajout du bouton export ici
     export_message  # Message d'état export
 )


### PR DESCRIPTION
## Summary
- add widgets for minimum and maximum mobility speed
- wire new controls into the Simulator call
- disable/enable controls when simulation runs
- document dashboard speed options in README

## Testing
- `python -m py_compile launcher/dashboard.py launcher/simulator.py launcher/smooth_mobility.py`
- `python -m py_compile run.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850c3e0b0288331a6fe9b124944bd79