### PR TITLE
Add global SF and power options

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -63,3 +63,11 @@ Le simulateur permet d'utiliser plusieurs canaux radio. Passez une instance
 `channels` et `channel_distribution`. Dans le `dashboard`, réglez **Nb
 sous-canaux** et **Répartition canaux** pour tester un partage Round‑robin ou
 aléatoire des fréquences entre les nœuds.
+
+## SF et puissance initiaux
+
+Deux nouvelles cases à cocher du tableau de bord permettent de fixer le
+Spreading Factor et/ou la puissance d'émission de tous les nœuds avant le
+lancement de la simulation. Une fois la case cochée, sélectionnez la valeur
+souhaitée via le curseur associé (SF 7‑12 et puissance 2‑14 dBm). Si la case est
+décochée, chaque nœud conserve des valeurs aléatoires par défaut.

--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -40,6 +40,13 @@ packets_input = pn.widgets.IntInput(name="Nombre de paquets (0=infin)", value=0,
 adr_node_checkbox = pn.widgets.Checkbox(name="ADR nœud", value=False)
 adr_server_checkbox = pn.widgets.Checkbox(name="ADR serveur", value=False)
 
+# --- Choix SF et puissance initiaux identiques ---
+fixed_sf_checkbox = pn.widgets.Checkbox(name="Choisir SF unique", value=False)
+sf_value_input = pn.widgets.IntSlider(name="SF initial", start=7, end=12, value=7, step=1, disabled=True)
+
+fixed_power_checkbox = pn.widgets.Checkbox(name="Choisir puissance unique", value=False)
+tx_power_input = pn.widgets.FloatSlider(name="Puissance Tx (dBm)", start=2, end=14, value=14, step=1, disabled=True)
+
 # --- Multi-canaux ---
 num_channels_input = pn.widgets.IntInput(name="Nb sous-canaux", value=1, step=1, start=1)
 channel_dist_select = pn.widgets.RadioButtonGroup(name="Répartition canaux", options=['Round-robin', 'Aléatoire'], value='Round-robin')
@@ -159,7 +166,9 @@ def on_start(event):
         adr_server=adr_server_checkbox.value,
         mobility=mobility_checkbox.value,
         channels=[868e6 + i * 200e3 for i in range(num_channels_input.value)],
-        channel_distribution='random' if channel_dist_select.value == 'Aléatoire' else 'round-robin'
+        channel_distribution='random' if channel_dist_select.value == 'Aléatoire' else 'round-robin',
+        fixed_sf=int(sf_value_input.value) if fixed_sf_checkbox.value else None,
+        fixed_tx_power=float(tx_power_input.value) if fixed_power_checkbox.value else None,
     )
 
     # La mobilité est désormais gérée directement par le simulateur
@@ -184,6 +193,10 @@ def on_start(event):
     packets_input.disabled = True
     adr_node_checkbox.disabled = True
     adr_server_checkbox.disabled = True
+    fixed_sf_checkbox.disabled = True
+    sf_value_input.disabled = True
+    fixed_power_checkbox.disabled = True
+    tx_power_input.disabled = True
     num_channels_input.disabled = True
     channel_dist_select.disabled = True
     mobility_checkbox.disabled = True
@@ -217,6 +230,10 @@ def on_stop(event):
     packets_input.disabled = False
     adr_node_checkbox.disabled = False
     adr_server_checkbox.disabled = False
+    fixed_sf_checkbox.disabled = False
+    sf_value_input.disabled = not fixed_sf_checkbox.value
+    fixed_power_checkbox.disabled = False
+    tx_power_input.disabled = not fixed_power_checkbox.value
     num_channels_input.disabled = False
     channel_dist_select.disabled = False
     mobility_checkbox.disabled = False
@@ -264,6 +281,16 @@ def on_mobility_toggle(event):
 
 mobility_checkbox.param.watch(on_mobility_toggle, 'value')
 
+# --- Activation des champs SF et puissance ---
+def on_fixed_sf_toggle(event):
+    sf_value_input.disabled = not event.new
+
+def on_fixed_power_toggle(event):
+    tx_power_input.disabled = not event.new
+
+fixed_sf_checkbox.param.watch(on_fixed_sf_toggle, 'value')
+fixed_power_checkbox.param.watch(on_fixed_power_toggle, 'value')
+
 # --- Associer les callbacks aux boutons ---
 start_button.on_click(on_start)
 stop_button.on_click(on_stop)
@@ -272,6 +299,8 @@ stop_button.on_click(on_stop)
 controls = pn.WidgetBox(
     num_nodes_input, num_gateways_input, area_input, mode_select, interval_input, packets_input,
     adr_node_checkbox, adr_server_checkbox,
+    fixed_sf_checkbox, sf_value_input,
+    fixed_power_checkbox, tx_power_input,
     num_channels_input, channel_dist_select,
     mobility_checkbox,
     pn.Row(start_button, stop_button, export_button),  # Ajout du bouton export ici

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -26,7 +26,9 @@ class Simulator:
                  packets_to_send: int = 0, adr_node: bool = False, adr_server: bool = False,
                  duty_cycle: float | None = 0.01, mobility: bool = True,
                  channels=None, channel_distribution: str = "round-robin",
-                 mobility_speed: tuple[float, float] = (2.0, 5.0)):
+                 mobility_speed: tuple[float, float] = (2.0, 5.0),
+                 fixed_sf: int | None = None,
+                 fixed_tx_power: float | None = None):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
         :param num_nodes: Nombre de nœuds à simuler.
@@ -47,6 +49,8 @@ class Simulator:
             gérer plusieurs canaux.
         :param channel_distribution: Méthode d'affectation des canaux aux nœuds
             ("round-robin" ou "random").
+        :param fixed_sf: Si défini, tous les nœuds démarrent avec ce SF.
+        :param fixed_tx_power: Si défini, puissance d'émission initiale commune (dBm).
         """
         # Paramètres de simulation
         self.num_nodes = num_nodes
@@ -57,6 +61,8 @@ class Simulator:
         self.packets_to_send = packets_to_send
         self.adr_node = adr_node
         self.adr_server = adr_server
+        self.fixed_sf = fixed_sf
+        self.fixed_tx_power = fixed_tx_power
         # Activation ou non de la mobilité des nœuds
         self.mobility_enabled = mobility
         self.mobility_model = SmoothMobility(area_size, mobility_speed[0], mobility_speed[1])
@@ -91,13 +97,13 @@ class Simulator:
                 gw_y = np.random.rand() * area_size
             self.gateways.append(Gateway(gw_id, gw_x, gw_y))
         
-        # Générer les nœuds aléatoirement dans l'aire et assigner un SF initial
+        # Générer les nœuds aléatoirement dans l'aire et assigner un SF/power initiaux
         self.nodes = []
         for node_id in range(self.num_nodes):
             x = np.random.rand() * area_size
             y = np.random.rand() * area_size
-            sf = np.random.randint(7, 13)        # SF aléatoire entre 7 et 12
-            tx_power = 14.0                      # Puissance d'émission typique en dBm
+            sf = self.fixed_sf if self.fixed_sf is not None else np.random.randint(7, 13)
+            tx_power = self.fixed_tx_power if self.fixed_tx_power is not None else 14.0
             channel = self.multichannel.select()
             node = Node(node_id, x, y, sf, tx_power, channel=channel)
             # Enregistrer les états initiaux du nœud pour rapport ultérieur


### PR DESCRIPTION
## Summary
- add widgets to optionally apply a single spreading factor and TX power
- support these fixed values in `Simulator`
- document new dashboard options in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850c4b786548331a28a11de91ee0f92