### PR TITLE
Account for frequency in collision detection

### DIFF
--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -213,8 +213,16 @@ class Simulator:
                 if best_rssi is None or rssi > best_rssi:
                     best_rssi = rssi
                 # Démarrer la réception à la passerelle (gestion des collisions et capture)
-                gw.start_reception(event_id, node_id, sf, rssi, end_time,
-                                   node.channel.capture_threshold_dB, self.current_time)
+                gw.start_reception(
+                    event_id,
+                    node_id,
+                    sf,
+                    rssi,
+                    end_time,
+                    node.channel.capture_threshold_dB,
+                    self.current_time,
+                    node.channel.frequency_hz,
+                )
             
             # Retenir le meilleur RSSI mesuré pour cette transmission
             node.last_rssi = best_rssi if heard_by_any else None


### PR DESCRIPTION
## Summary
- update `Gateway.start_reception` to consider frequency
- pass frequency from simulator when starting receptions

## Testing
- `python -m py_compile VERSION_3/launcher/*.py VERSION_3/run.py`

------
https://chatgpt.com/codex/tasks/task_e_6850c58c77e8833186c9c173f6f85ea2