### PR TITLE
Add basic LoRaWAN layer

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -73,3 +73,17 @@ Spreading Factor et/ou la puissance d'émission de tous les nœuds avant le
 lancement de la simulation. Une fois la case cochée, sélectionnez la valeur
 souhaitée via le curseur associé (SF 7‑12 et puissance 2‑14 dBm). Si la case est
 décochée, chaque nœud conserve des valeurs aléatoires par défaut.
+
+## Fonctionnalités LoRaWAN
+
+Une couche LoRaWAN simplifiée est maintenant disponible. Le module
+`lorawan.py` définit la structure `LoRaWANFrame` ainsi que les fenêtres
+`RX1` et `RX2`. Les nœuds possèdent des compteurs de trames et les passerelles
+peuvent mettre en file d'attente des downlinks via `NetworkServer.send_downlink`.
+
+Lancer l'exemple minimal :
+
+```bash
+python run.py --lorawan-demo
+```
+ 

--- a/VERSION_3/launcher/__init__.py
+++ b/VERSION_3/launcher/__init__.py
@@ -7,3 +7,4 @@ from .server import NetworkServer
 from .simulator import Simulator
 from .duty_cycle import DutyCycleManager
 from .smooth_mobility import SmoothMobility
+from .lorawan import LoRaWANFrame, compute_rx1, compute_rx2

--- a/VERSION_3/launcher/lorawan.py
+++ b/VERSION_3/launcher/lorawan.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+@dataclass
+class LoRaWANFrame:
+    """Minimal representation of a LoRaWAN MAC frame."""
+    mhdr: int
+    fctrl: int
+    fcnt: int
+    payload: bytes
+    confirmed: bool = False
+
+
+def compute_rx1(end_time: float) -> float:
+    """Return the opening time of RX1 window after an uplink."""
+    return end_time + 1.0
+
+
+def compute_rx2(end_time: float) -> float:
+    """Return the opening time of RX2 window after an uplink."""
+    return end_time + 2.0

--- a/VERSION_3/run.py
+++ b/VERSION_3/run.py
@@ -60,10 +60,27 @@ if __name__ == "__main__":
     parser.add_argument("--interval", type=int, default=10, help="Intervalle moyen ou fixe entre transmissions")
     parser.add_argument("--steps", type=int, default=100, help="Nombre de pas de temps de la simulation")
     parser.add_argument("--output", type=str, help="Fichier CSV pour sauvegarder les résultats (optionnel)")
+    parser.add_argument("--lorawan-demo", action="store_true", help="Exécute un exemple LoRaWAN")
     args = parser.parse_args()
 
     logging.info(f"Simulation d'un réseau LoRa : {args.nodes} nœuds, {args.gateways} gateways, "
                  f"aire={args.area}m, mode={args.mode}, intervalle={args.interval}, steps={args.steps}")
+    if args.lorawan_demo:
+        from launcher.node import Node
+        from launcher.gateway import Gateway
+        from launcher.server import NetworkServer
+
+        gw = Gateway(0, 0, 0)
+        ns = NetworkServer()
+        ns.gateways = [gw]
+        node = Node(0, 0, 0, 7, 14)
+        frame = node.prepare_uplink(b"ping", confirmed=True)
+        ns.send_downlink(node, b"ack")
+        rx1, _ = node.schedule_receive_windows(0)
+        gw.pop_downlink(node.id)  # illustration
+        logging.info(f"Exemple LoRaWAN : trame uplink FCnt={frame.fcnt}, RX1={rx1}s")
+        exit()
+
     delivered, collisions, pdr, energy, avg_delay = simulate(
         args.nodes, args.gateways, args.area, args.mode, args.interval, args.steps
     )


### PR DESCRIPTION
## Summary
- add LoRaWANFrame helper module
- extend Node with LoRaWAN counters and helper methods
- allow gateways and server to buffer and send downlinks
- schedule receive windows in Simulator and basic classes B/C handling
- add demo option to run.py and document LoRaWAN usage

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python VERSION_3/run.py --lorawan-demo` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850c7f9e57c83318601175ae1c3c60b