### PR TITLE
Add noise model and SNR based reception

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -66,6 +66,19 @@ Le simulateur permet d'utiliser plusieurs canaux radio. Passez une instance
 sous-canaux** et **Répartition canaux** pour tester un partage Round‑robin ou
 aléatoire des fréquences entre les nœuds.
 
+## Paramètres radio avancés
+
+Le constructeur `Channel` accepte trois options pour modéliser plus finement la
+réception :
+
+- `cable_loss` : pertes fixes (dB) entre le transceiver et l'antenne.
+- `receiver_noise_floor` : bruit thermique de référence en dBm/Hz (par défaut
+  `-174`).
+- `noise_figure` : facteur de bruit du récepteur en dB.
+
+Ces valeurs influencent le calcul du RSSI et du SNR retournés par
+`Channel.compute_rssi`.
+
 ## SF et puissance initiaux
 
 Deux nouvelles cases à cocher du tableau de bord permettent de fixer le


### PR DESCRIPTION
## Summary
- model cable loss and receiver noise figure in `Channel`
- compute RSSI and SNR together
- use SNR threshold for packet reception
- document new channel parameters in README

## Testing
- `python -m py_compile launcher/channel.py launcher/simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_6850cb9b90d8833191d735444390ac84