### PR TITLE
Fix markdown code block

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -33,6 +33,7 @@ python run.py --nodes 20 --mode Random --interval 15
 python run.py --nodes 5 --mode Periodic --interval 10
 
 panel serve dashboard.py --show
+```
 
 ## Duty cycle
 


### PR DESCRIPTION
## Summary
- close a misplaced code block in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850cd1cb52083318c53f093f818cd40