### PR TITLE
Add basic LinkADRReq/Ans support

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -95,6 +95,11 @@ Une couche LoRaWAN simplifiée est maintenant disponible. Le module
 `RX1` et `RX2`. Les nœuds possèdent des compteurs de trames et les passerelles
 peuvent mettre en file d'attente des downlinks via `NetworkServer.send_downlink`.
 
+Depuis cette version, les commandes `LinkADRReq`/`LinkADRAns` sont gérées afin
+d'ajuster le Spreading Factor et la puissance d'émission selon la spécification
+LoRaWAN. Le serveur encode la requête et le nœud y répond automatiquement lors
+du prochain uplink.
+
 Lancer l'exemple minimal :
 
 ```bash

--- a/VERSION_3/launcher/lorawan.py
+++ b/VERSION_3/launcher/lorawan.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class LoRaWANFrame:
     """Minimal representation of a LoRaWAN MAC frame."""
@@ -8,6 +9,49 @@ class LoRaWANFrame:
     fcnt: int
     payload: bytes
     confirmed: bool = False
+
+
+# ---------------------------------------------------------------------------
+# LoRaWAN ADR MAC commands (simplified)
+# ---------------------------------------------------------------------------
+
+DR_TO_SF = {0: 12, 1: 11, 2: 10, 3: 9, 4: 8, 5: 7}
+SF_TO_DR = {sf: dr for dr, sf in DR_TO_SF.items()}
+TX_POWER_INDEX_TO_DBM = {0: 14.0, 1: 11.0, 2: 8.0, 3: 5.0, 4: 2.0}
+DBM_TO_TX_POWER_INDEX = {int(v): k for k, v in TX_POWER_INDEX_TO_DBM.items()}
+
+
+@dataclass
+class LinkADRReq:
+    datarate: int
+    tx_power: int
+    chmask: int = 0xFFFF
+    redundancy: int = 0
+
+    def to_bytes(self) -> bytes:
+        dr_tx = ((self.datarate & 0x0F) << 4) | (self.tx_power & 0x0F)
+        return bytes([0x03, dr_tx]) + self.chmask.to_bytes(2, "little") + bytes([
+            self.redundancy
+        ])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "LinkADRReq":
+        if len(data) < 5 or data[0] != 0x03:
+            raise ValueError("Invalid LinkADRReq")
+        dr_tx = data[1]
+        datarate = (dr_tx >> 4) & 0x0F
+        tx_power = dr_tx & 0x0F
+        chmask = int.from_bytes(data[2:4], "little")
+        redundancy = data[4]
+        return LinkADRReq(datarate, tx_power, chmask, redundancy)
+
+
+@dataclass
+class LinkADRAns:
+    status: int = 0b111
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x03, self.status])
 
 
 def compute_rx1(end_time: float) -> float:


### PR DESCRIPTION
## Summary
- implement simplified LinkADRReq/LinkADRAns handling
- wire ADR commands into nodes and network server
- mention LinkADRReq support in README

## Testing
- `python -m py_compile VERSION_3/launcher/lorawan.py VERSION_3/launcher/node.py VERSION_3/launcher/server.py VERSION_3/launcher/simulator.py VERSION_3/run.py`
- `python VERSION_3/run.py --lorawan-demo` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850d13adc80833190c938a83e183ad5