### PR TITLE
Fix mobility initialization and layout

### DIFF
--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -104,11 +104,11 @@ def update_map():
         name="Nœuds",
         text=node_ids,
         textposition="middle center",
-        marker=dict(symbol="circle", color="blue", size=12),
+        marker=dict(symbol="circle", color="blue", size=16),
     )
     x_gw = [gw.x for gw in sim.gateways]
     y_gw = [gw.y for gw in sim.gateways]
-    gw_ids = [str(gw.id + 1) for gw in sim.gateways]
+    gw_ids = [str(gw.id) for gw in sim.gateways]
     fig.add_scatter(
         x=x_gw,
         y=y_gw,
@@ -116,7 +116,7 @@ def update_map():
         name="Passerelles",
         text=gw_ids,
         textposition="middle center",
-        marker=dict(symbol="star", color="red", size=18, line=dict(width=1, color="black")),
+        marker=dict(symbol="star", color="red", size=24, line=dict(width=1, color="black")),
     )
     area = area_input.value
     fig.update_layout(
@@ -374,7 +374,7 @@ center_col = pn.Column(
     sf_hist_pane,
     sizing_mode="stretch_width",
 )
-center_col.width = 650
+center_col.width = 600
 
 dashboard = pn.Row(
     controls,

--- a/VERSION_3/launcher/id_provider.py
+++ b/VERSION_3/launcher/id_provider.py
@@ -1,0 +1,23 @@
+_node_counter = 0
+_gateway_counter = 0
+
+
+def next_node_id() -> int:
+    """Return a new unique node identifier."""
+    global _node_counter
+    _node_counter += 1
+    return _node_counter
+
+
+def next_gateway_id() -> int:
+    """Return a new unique gateway identifier."""
+    global _gateway_counter
+    _gateway_counter += 1
+    return _gateway_counter
+
+
+def reset() -> None:
+    """Reset both node and gateway counters."""
+    global _node_counter, _gateway_counter
+    _node_counter = 0
+    _gateway_counter = 0

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -15,6 +15,7 @@ from .multichannel import MultiChannel
 from .server import NetworkServer
 from .duty_cycle import DutyCycleManager
 from .smooth_mobility import SmoothMobility
+from .id_provider import next_node_id, next_gateway_id, reset as reset_ids
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,9 @@ class Simulator:
         
         # Générer les passerelles
         self.gateways = []
-        for gw_id in range(self.num_gateways):
+        reset_ids()
+        for _ in range(self.num_gateways):
+            gw_id = next_gateway_id()
             if self.num_gateways == 1:
                 # Une seule passerelle au centre de l'aire
                 gw_x = area_size / 2.0
@@ -103,7 +106,8 @@ class Simulator:
         
         # Générer les nœuds aléatoirement dans l'aire et assigner un SF/power initiaux
         self.nodes = []
-        for node_id in range(self.num_nodes):
+        for _ in range(self.num_nodes):
+            node_id = next_node_id()
             x = random.random() * area_size
             y = random.random() * area_size
             sf = self.fixed_sf if self.fixed_sf is not None else random.randint(7, 12)

--- a/VERSION_3/launcher/smooth_mobility.py
+++ b/VERSION_3/launcher/smooth_mobility.py
@@ -4,7 +4,19 @@ import random
 
 def bezier_point(p0, p1, p2, p3, t):
     """Return point of cubic Bezier curve for parameter t."""
-    return ((1 - t) ** 3) * p0 + 3 * ((1 - t) ** 2) * t * p1 + 3 * (1 - t) * (t ** 2) * p2 + (t ** 3) * p3
+    x = (
+        ((1 - t) ** 3) * p0[0]
+        + 3 * ((1 - t) ** 2) * t * p1[0]
+        + 3 * (1 - t) * (t ** 2) * p2[0]
+        + (t ** 3) * p3[0]
+    )
+    y = (
+        ((1 - t) ** 3) * p0[1]
+        + 3 * ((1 - t) ** 2) * t * p1[1]
+        + 3 * (1 - t) * (t ** 2) * p2[1]
+        + (t ** 3) * p3[1]
+    )
+    return x, y
 
 
 class SmoothMobility:


### PR DESCRIPTION
## Summary
- fix cubic Bézier mobility interpolation
- manage unique node and gateway IDs via new id_provider module
- increase node and gateway marker sizes
- narrow central column width for better fit

## Testing
- `pytest -q`
- `python -m compileall launcher`

------
https://chatgpt.com/codex/tasks/task_e_6850da15fbc4833195a8050e13846b19