### PR TITLE
Fix launcher import path

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -1,1 +1,24 @@
-from VERSION_3.launcher import *
+"""Compatibility wrapper exposing the versioned launcher package.
+
+This package simply re-exports everything from :mod:`VERSION_3.launcher` while
+also making its submodules importable as ``launcher.<module>``.  Without this
+extra step an ``ImportError`` would be raised when trying to import a module
+such as ``launcher.simulator`` because the actual sources live under
+``VERSION_3/launcher``.
+"""
+
+from __future__ import annotations
+
+import os
+from importlib import import_module
+
+# Add the real package location to ``__path__`` so that ``import
+# launcher.simulator`` works as expected.
+_pkg_dir = os.path.join(os.path.dirname(__file__), "..", "VERSION_3", "launcher")
+__path__.append(os.path.abspath(_pkg_dir))
+
+# Re-export public symbols from the versioned package.
+module = import_module("VERSION_3.launcher")
+for name in getattr(module, "__all__", []):
+    globals()[name] = getattr(module, name)
+


### PR DESCRIPTION
## Summary
- update compatibility wrapper so that `launcher.simulator` etc. work

## Testing
- `pytest -q`
- `python VERSION_3/run.py --lorawan-demo`


------
https://chatgpt.com/codex/tasks/task_e_6850df11cc3c8331ab7aa3129766186d