### PR TITLE
Increase mobility speed limit

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -40,7 +40,7 @@ nœuds ». Si elle est décochée, les positions des nœuds restent fixes penda
 la simulation.
 Lorsque la mobilité est active, les déplacements sont progressifs et suivent
 des trajectoires lissées par interpolation de Bézier. La vitesse des nœuds est
-tirée aléatoirement dans la plage spécifiée (par défaut 2 à 5 m/s) et peut être
+tirée aléatoirement dans la plage spécifiée (par défaut 2 à 10 m/s) et peut être
 modifiée via le paramètre `mobility_speed` du `Simulator`. Les mouvements sont
 donc continus et sans téléportation.
 Deux champs « Vitesse min » et « Vitesse max » sont disponibles dans le

--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -60,7 +60,7 @@ mobility_checkbox = pn.widgets.Checkbox(name="Activer la mobilité des nœuds", 
 
 # Widgets pour régler la vitesse minimale et maximale des nœuds mobiles
 mobility_speed_min_input = pn.widgets.FloatInput(name="Vitesse min (m/s)", value=2.0, step=0.5, start=0.1)
-mobility_speed_max_input = pn.widgets.FloatInput(name="Vitesse max (m/s)", value=5.0, step=0.5, start=0.1)
+mobility_speed_max_input = pn.widgets.FloatInput(name="Vitesse max (m/s)", value=10.0, step=0.5, start=0.1)
 
 # --- Boutons de contrôle ---
 start_button = pn.widgets.Button(name="Lancer la simulation", button_type="success")

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -31,7 +31,7 @@ class Simulator:
                  packets_to_send: int = 0, adr_node: bool = False, adr_server: bool = False,
                  duty_cycle: float | None = 0.01, mobility: bool = True,
                  channels=None, channel_distribution: str = "round-robin",
-                 mobility_speed: tuple[float, float] = (2.0, 5.0),
+                 mobility_speed: tuple[float, float] = (2.0, 10.0),
                  fixed_sf: int | None = None,
                  fixed_tx_power: float | None = None):
         """

--- a/VERSION_3/launcher/smooth_mobility.py
+++ b/VERSION_3/launcher/smooth_mobility.py
@@ -22,7 +22,7 @@ def bezier_point(p0, p1, p2, p3, t):
 class SmoothMobility:
     """Smooth node mobility based on cubic Bezier interpolation."""
 
-    def __init__(self, area_size: float, min_speed: float = 2.0, max_speed: float = 5.0, step: float = 1.0):
+    def __init__(self, area_size: float, min_speed: float = 2.0, max_speed: float = 10.0, step: float = 1.0):
         self.area_size = area_size
         self.min_speed = min_speed
         self.max_speed = max_speed


### PR DESCRIPTION
## Summary
- bump max mobility speed from 5 m/s to 10 m/s
- update dashboard default value
- document the new speed range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536ddb91488331a8ef04070344bd36