### PR TITLE
Add __all__ and public exports

### DIFF
--- a/VERSION_3/launcher/__init__.py
+++ b/VERSION_3/launcher/__init__.py
@@ -8,3 +8,20 @@ from .simulator import Simulator
 from .duty_cycle import DutyCycleManager
 from .smooth_mobility import SmoothMobility
 from .lorawan import LoRaWANFrame, compute_rx1, compute_rx2
+
+__all__ = [
+    "Node",
+    "Gateway",
+    "Channel",
+    "MultiChannel",
+    "NetworkServer",
+    "Simulator",
+    "DutyCycleManager",
+    "SmoothMobility",
+    "LoRaWANFrame",
+    "compute_rx1",
+    "compute_rx2",
+]
+
+for name in __all__:
+    globals()[name] = locals()[name]


### PR DESCRIPTION
## Summary
- define public API symbols in `VERSION_3/launcher/__init__.py`
- populate module globals using `__all__`

## Testing
- `pytest -q`
- `python - <<'PY'
import launcher
from launcher import Simulator
print('Simulator', Simulator)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68536e056e8083319366888f97ea5f10