### PR TITLE
Fix node attributes and add type hints

### DIFF
--- a/VERSION_3/launcher/duty_cycle.py
+++ b/VERSION_3/launcher/duty_cycle.py
@@ -5,7 +5,7 @@ class DutyCycleManager:
             raise ValueError("duty_cycle must be in (0,1]")
         self.duty_cycle = duty_cycle
         # next allowed transmission time per node id
-        self.next_tx_time = {}
+        self.next_tx_time: dict[int, float] = {}
 
     def can_transmit(self, node_id: int, time: float) -> bool:
         """Return True if node can transmit at given time."""

--- a/VERSION_3/launcher/gateway.py
+++ b/VERSION_3/launcher/gateway.py
@@ -17,9 +17,9 @@ class Gateway:
         # Liste des transmissions actuellement en cours de réception sur cette passerelle
         # Chaque élément est un dictionnaire avec 'event_id', 'node_id', 'sf',
         # 'frequency', 'rssi', 'end_time' et 'lost_flag'
-        self.active_transmissions = []
+        self.active_transmissions: list[dict] = []
         # Downlink frames waiting for the corresponding node receive windows
-        self.downlink_buffer = {}
+        self.downlink_buffer: dict[int, list] = {}
 
     def start_reception(self, event_id: int, node_id: int, sf: int, rssi: float,
                         end_time: float, capture_threshold: float, current_time: float,

--- a/VERSION_3/launcher/node.py
+++ b/VERSION_3/launcher/node.py
@@ -69,6 +69,13 @@ class Node:
         self.awaiting_ack = False
         self.pending_mac_cmd = None
 
+        # Additional state used by the simulator
+        self.history: list[dict] = []
+        self.in_transmission: bool = False
+        self.current_end_time: float | None = None
+        self.last_rssi: float | None = None
+        self.last_snr: float | None = None
+
     def distance_to(self, other) -> float:
         """
         Calcule la distance euclidienne (mètres) entre ce nœud et un autre objet possédant 

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -136,7 +136,7 @@ class Simulator:
         self.network_server.channel = self.channel
         
         # File d'événements (min-heap)
-        self.event_queue = []
+        self.event_queue: list[tuple[float, int, int, Node]] = []
         self.current_time = 0.0
         self.event_id_counter = 0
         
@@ -150,7 +150,7 @@ class Simulator:
         self.delivered_count = 0
         
         # Journal des événements (pour export CSV)
-        self.events_log = []
+        self.events_log: list[dict] = []
         
         # Planifier le premier envoi de chaque nœud
         for node in self.nodes:
@@ -439,7 +439,7 @@ class Simulator:
         # Si autre type d'événement (non prévu)
         return True
     
-    def run(self, max_steps: int = None):
+    def run(self, max_steps: int | None = None):
         """Exécute la simulation en traitant les événements jusqu'à épuisement ou jusqu'à une limite optionnelle."""
         step_count = 0
         while self.event_queue and self.running:


### PR DESCRIPTION
## Summary
- ensure runtime attributes are pre-initialized for `Node`
- annotate duty cycle and gateway containers
- type annotate simulator event queue and events log
- fix `run` signature to allow `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685370abb8688331917518947848a878