### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ python run.py --nodes 20 --steps 100
 ```
 
 For a detailed description of all options, see `VERSION_3/README.md`.
+
+This project is licensed under the [MIT License](LICENSE).

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -92,4 +92,6 @@ Lancer l'exemple minimal :
 ```bash
 python run.py --lorawan-demo
 ```
+
+Ce projet est distribué sous licence [MIT](../LICENSE).
  


### PR DESCRIPTION
## Summary
- add MIT license
- reference the license in both README files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685371a6f0008331a7078064cdf864bb