### PR TITLE
Set max TX power to 20 dBm

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -72,7 +72,7 @@ Ces valeurs influencent le calcul du RSSI et du SNR retournés par
 Deux nouvelles cases à cocher du tableau de bord permettent de fixer le
 Spreading Factor et/ou la puissance d'émission de tous les nœuds avant le
 lancement de la simulation. Une fois la case cochée, sélectionnez la valeur
-souhaitée via le curseur associé (SF 7‑12 et puissance 2‑14 dBm). Si la case est
+souhaitée via le curseur associé (SF 7‑12 et puissance 2‑20 dBm). Si la case est
 décochée, chaque nœud conserve des valeurs aléatoires par défaut.
 
 ## Fonctionnalités LoRaWAN

--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -47,7 +47,7 @@ fixed_sf_checkbox = pn.widgets.Checkbox(name="Choisir SF unique", value=False)
 sf_value_input = pn.widgets.IntSlider(name="SF initial", start=7, end=12, value=7, step=1, disabled=True)
 
 fixed_power_checkbox = pn.widgets.Checkbox(name="Choisir puissance unique", value=False)
-tx_power_input = pn.widgets.FloatSlider(name="Puissance Tx (dBm)", start=2, end=14, value=14, step=1, disabled=True)
+tx_power_input = pn.widgets.FloatSlider(name="Puissance Tx (dBm)", start=2, end=20, value=14, step=1, disabled=True)
 
 # --- Multi-canaux ---
 num_channels_input = pn.widgets.IntInput(name="Nb sous-canaux", value=1, step=1, start=1)

--- a/VERSION_3/launcher/lorawan.py
+++ b/VERSION_3/launcher/lorawan.py
@@ -17,7 +17,15 @@ class LoRaWANFrame:
 
 DR_TO_SF = {0: 12, 1: 11, 2: 10, 3: 9, 4: 8, 5: 7}
 SF_TO_DR = {sf: dr for dr, sf in DR_TO_SF.items()}
-TX_POWER_INDEX_TO_DBM = {0: 14.0, 1: 11.0, 2: 8.0, 3: 5.0, 4: 2.0}
+TX_POWER_INDEX_TO_DBM = {
+    0: 20.0,
+    1: 17.0,
+    2: 14.0,
+    3: 11.0,
+    4: 8.0,
+    5: 5.0,
+    6: 2.0,
+}
 DBM_TO_TX_POWER_INDEX = {int(v): k for k, v in TX_POWER_INDEX_TO_DBM.items()}
 
 

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -354,8 +354,8 @@ class Simulator:
                             # Lien de mauvaise qualité – augmenter la portée (augmenter SF ou puissance)
                             if node.sf < 12:
                                 node.sf += 1  # augmenter SF (ralentir le débit pour plus de portée)
-                            elif node.tx_power < 14.0:
-                                node.tx_power = min(14.0, node.tx_power + 3.0)  # augmenter puissance de 3 dB
+                            elif node.tx_power < 20.0:
+                                node.tx_power = min(20.0, node.tx_power + 3.0)  # augmenter puissance de 3 dB
                         elif margin_val is not None and margin_val > 0:
                             # Lien avec bonne marge – optimiser en réduisant SF et/ou puissance
                             steps = int(margin_val // 3)  # nombre d'incréments de 3 dB exploitables

--- a/VERSION_3/run.py
+++ b/VERSION_3/run.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
         gw = Gateway(0, 0, 0)
         ns = NetworkServer()
         ns.gateways = [gw]
-        node = Node(0, 0, 0, 7, 14)
+        node = Node(0, 0, 0, 7, 20)
         frame = node.prepare_uplink(b"ping", confirmed=True)
         ns.send_downlink(node, b"ack")
         rx1, _ = node.schedule_receive_windows(0)


### PR DESCRIPTION
## Summary
- allow selecting up to 20 dBm in the dashboard
- document 2‑20 dBm power range in README
- extend LoRaWAN power index table up to 20 dBm
- raise ADR maximum power to 20 dBm
- update CLI example with new power level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685375718f1c8331a20dbf62012367cf