### PR TITLE
Add radio metrics to simulation exports

### DIFF
--- a/VERSION_3/launcher/node.py
+++ b/VERSION_3/launcher/node.py
@@ -75,6 +75,8 @@ class Node:
         self.current_end_time: float | None = None
         self.last_rssi: float | None = None
         self.last_snr: float | None = None
+        self.downlink_pending: int = 0
+        self.acks_received: int = 0
 
     def distance_to(self, other) -> float:
         """
@@ -114,7 +116,9 @@ class Node:
             'energy_consumed_J': self.energy_consumed,
             'packets_sent': self.packets_sent,
             'packets_success': self.packets_success,
-            'packets_collision': self.packets_collision
+            'packets_collision': self.packets_collision,
+            'downlink_pending': self.downlink_pending,
+            'acks_received': self.acks_received
         }
 
     def increment_sent(self):
@@ -163,6 +167,9 @@ class Node:
         self.fcnt_down = frame.fcnt + 1
         if frame.confirmed:
             self.awaiting_ack = False
+            self.acks_received += 1
+
+        self.downlink_pending = max(0, self.downlink_pending - 1)
 
         if isinstance(frame.payload, bytes):
             if len(frame.payload) >= 5 and frame.payload[0] == 0x03:

--- a/VERSION_3/launcher/server.py
+++ b/VERSION_3/launcher/server.py
@@ -50,6 +50,10 @@ class NetworkServer:
             frame.payload = LinkADRReq(dr, p_idx).to_bytes()
         node.fcnt_down += 1
         gw.buffer_downlink(node.id, frame)
+        try:
+            node.downlink_pending += 1
+        except AttributeError:
+            pass
 
     def receive(self, event_id: int, node_id: int, gateway_id: int, rssi: float | None = None):
         """

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -287,6 +287,8 @@ class Simulator:
                 'end_time': end_time,
                 'energy_J': energy_J,
                 'heard': heard_by_any,
+                'rssi_dBm': best_rssi,
+                'snr_dB': best_snr,
                 'result': None,
                 'gateway_id': None
             })
@@ -430,7 +432,9 @@ class Simulator:
                     'heard': None,
                     'result': 'Mobility',
                     'energy_J': 0.0,
-                    'gateway_id': None
+                    'gateway_id': None,
+                    'rssi_dBm': None,
+                    'snr_dB': None
                 })
                 if self.mobility_enabled and (self.packets_to_send == 0 or self.packets_sent < self.packets_to_send):
                     self.schedule_mobility(node, time + self.mobility_model.step)
@@ -487,11 +491,20 @@ class Simulator:
         df['final_sf'] = df['node_id'].apply(lambda nid: node_dict[nid].sf)
         df['initial_tx_power'] = df['node_id'].apply(lambda nid: node_dict[nid].initial_tx_power)
         df['final_tx_power'] = df['node_id'].apply(lambda nid: node_dict[nid].tx_power)
+        df['packets_sent'] = df['node_id'].apply(lambda nid: node_dict[nid].packets_sent)
+        df['packets_success'] = df['node_id'].apply(lambda nid: node_dict[nid].packets_success)
+        df['packets_collision'] = df['node_id'].apply(lambda nid: node_dict[nid].packets_collision)
+        df['energy_consumed_J_node'] = df['node_id'].apply(lambda nid: node_dict[nid].energy_consumed)
+        df['downlink_pending'] = df['node_id'].apply(lambda nid: node_dict[nid].downlink_pending)
+        df['acks_received'] = df['node_id'].apply(lambda nid: node_dict[nid].acks_received)
         # Colonnes d'intérêt dans un ordre lisible
         columns_order = [
             'event_id', 'node_id', 'initial_x', 'initial_y', 'final_x', 'final_y',
             'initial_sf', 'final_sf', 'initial_tx_power', 'final_tx_power',
-            'start_time', 'end_time', 'energy_J', 'result', 'gateway_id'
+            'packets_sent', 'packets_success', 'packets_collision',
+            'energy_consumed_J_node', 'downlink_pending', 'acks_received',
+            'start_time', 'end_time', 'energy_J', 'rssi_dBm', 'snr_dB',
+            'result', 'gateway_id'
         ]
         for col in columns_order:
             if col not in df.columns:


### PR DESCRIPTION
## Summary
- track downlink queue and ACK count per node
- log RSSI and SNR for each received message
- include node metrics in exported dataframe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685375524d0c8331a40294fda32ef815