### PR TITLE
Add CSV format doc and analysis example

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -93,5 +93,39 @@ Lancer l'exemple minimal :
 python run.py --lorawan-demo
 ```
 
+## Format du fichier CSV
+
+L'option `--output` de `run.py` permet d'enregistrer les métriques de la
+simulation dans un fichier CSV. Ce dernier contient l'en‑tête suivant :
+
+```
+nodes,gateways,area,mode,interval,steps,delivered,collisions,PDR(%),energy,avg_delay
+```
+
+* **nodes** : nombre de nœuds simulés.
+* **gateways** : nombre de passerelles.
+* **area** : côté du carré de simulation en mètres.
+* **mode** : `Random` ou `Periodic`.
+* **interval** : intervalle moyen/fixe entre deux transmissions.
+* **steps** : nombre de pas de temps simulés.
+* **delivered** : paquets reçus par au moins une passerelle.
+* **collisions** : paquets perdus par collision.
+* **PDR(%)** : taux de livraison en pourcentage.
+* **energy** : énergie totale consommée (unités arbitraires).
+* **avg_delay** : délai moyen des paquets livrés.
+
+## Exemple d'analyse
+
+Un script Python d'exemple nommé `analyse_resultats.py` est disponible dans le
+dossier `examples`. Il agrège plusieurs fichiers CSV et trace le PDR en fonction
+du nombre de nœuds :
+
+```bash
+python examples/analyse_resultats.py resultats1.csv resultats2.csv
+```
+
+Le script affiche le PDR moyen puis sauvegarde un graphique dans
+`pdr_par_nodes.png`.
+
 Ce projet est distribué sous licence [MIT](../LICENSE).
  

--- a/examples/analyse_resultats.py
+++ b/examples/analyse_resultats.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Analyse simple des fichiers CSV générés par le simulateur."""
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+
+if len(sys.argv) < 2:
+    print("Usage: python analyse_resultats.py fichier1.csv [fichier2.csv ...]")
+    sys.exit(1)
+
+dfs = [pd.read_csv(f) for f in sys.argv[1:]]
+results = pd.concat(dfs, ignore_index=True)
+
+# Conversion des colonnes numériques
+results['PDR(%)'] = results['PDR(%)'].astype(float)
+results['energy'] = results['energy'].astype(float)
+
+print(results)
+print(f"PDR moyen: {results['PDR(%)'].mean():.2f}%")
+
+plt.figure()
+results.plot(x='nodes', y='PDR(%)', kind='bar')
+plt.ylabel('PDR (%)')
+plt.title('Taux de livraison par nombre de noeuds')
+plt.tight_layout()
+plt.savefig('pdr_par_nodes.png')
+print("Graphique enregistré dans pdr_par_nodes.png")
+


### PR DESCRIPTION
## Summary
- document CSV output format
- describe a simple analysis routine
- add `examples/analyse_resultats.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685375a31b5883319fcbf656ac16190e