### PR TITLE
Fix identifier text color on map

### DIFF
--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -105,6 +105,7 @@ def update_map():
         text=node_ids,
         textposition="middle center",
         marker=dict(symbol="circle", color="blue", size=16),
+        textfont=dict(color="white"),
     )
     x_gw = [gw.x for gw in sim.gateways]
     y_gw = [gw.y for gw in sim.gateways]
@@ -117,6 +118,7 @@ def update_map():
         text=gw_ids,
         textposition="middle center",
         marker=dict(symbol="star", color="red", size=24, line=dict(width=1, color="black")),
+        textfont=dict(color="white"),
     )
     area = area_input.value
     fig.update_layout(


### PR DESCRIPTION
## Summary
- update dashboard map scatter plots to display identifiers in white

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537642502083319d456702d6ba3760