### PR TITLE
Fix missing __all__ in wrapper package

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -19,6 +19,7 @@ __path__.append(os.path.abspath(_pkg_dir))
 
 # Re-export public symbols from the versioned package.
 module = import_module("VERSION_3.launcher")
-for name in getattr(module, "__all__", []):
+__all__ = list(getattr(module, "__all__", []))
+for name in __all__:
     globals()[name] = getattr(module, name)
 


### PR DESCRIPTION
## Summary
- ensure `launcher.__all__` is exported

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537893a25c8331b958204411cae8d8