### PR TITLE
Add advanced LoRaWAN helpers

### DIFF
--- a/VERSION_3/launcher/lorawan.py
+++ b/VERSION_3/launcher/lorawan.py
@@ -62,6 +62,54 @@ class LinkADRAns:
         return bytes([0x03, self.status])
 
 
+@dataclass
+class LinkCheckReq:
+    """LinkCheckReq MAC command"""
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x02])
+
+
+@dataclass
+class LinkCheckAns:
+    margin: int
+    gw_cnt: int
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x02, self.margin & 0xFF, self.gw_cnt & 0xFF])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "LinkCheckAns":
+        if len(data) < 3 or data[0] != 0x02:
+            raise ValueError("Invalid LinkCheckAns")
+        return LinkCheckAns(margin=data[1], gw_cnt=data[2])
+
+
+@dataclass
+class DeviceTimeReq:
+    """DeviceTimeReq MAC command"""
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x0D])
+
+
+@dataclass
+class DeviceTimeAns:
+    seconds: int
+    fractional: int = 0
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x0D]) + self.seconds.to_bytes(4, "little") + bytes([self.fractional & 0xFF])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "DeviceTimeAns":
+        if len(data) < 6 or data[0] != 0x0D:
+            raise ValueError("Invalid DeviceTimeAns")
+        secs = int.from_bytes(data[1:5], "little")
+        frac = data[5]
+        return DeviceTimeAns(secs, frac)
+
+
 def compute_rx1(end_time: float) -> float:
     """Return the opening time of RX1 window after an uplink."""
     return end_time + 1.0

--- a/VERSION_3/launcher/server.py
+++ b/VERSION_3/launcher/server.py
@@ -28,6 +28,7 @@ class NetworkServer:
         payload: bytes = b"",
         confirmed: bool = False,
         adr_command: tuple[int, float] | None = None,
+        request_ack: bool = False,
     ):
         """Queue a downlink frame for a node via the first gateway."""
         from .lorawan import (
@@ -40,8 +41,9 @@ class NetworkServer:
         gw = self.gateways[0] if self.gateways else None
         if gw is None:
             return
+        fctrl = 0x20 if request_ack else 0
         frame = LoRaWANFrame(
-            mhdr=0x60, fctrl=0, fcnt=node.fcnt_down, payload=payload, confirmed=confirmed
+            mhdr=0x60, fctrl=fctrl, fcnt=node.fcnt_down, payload=payload, confirmed=confirmed
         )
         if adr_command:
             sf, power = adr_command


### PR DESCRIPTION
## Summary
- extend LoRaWAN MAC support with LinkCheck and DeviceTime commands
- support acknowledgments for downlinks via FCtrl bit
- expose request_ack option on server.send_downlink
- test new MAC commands and ACK handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d44f4d208331a6226655e24f4732