### PR TITLE
Add advanced network metrics

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -128,4 +128,13 @@ Le script affiche le PDR moyen puis sauvegarde un graphique dans
 `pdr_par_nodes.png`.
 
 Ce projet est distribué sous licence [MIT](../LICENSE).
+
+## Améliorations possibles
+
+Pour aller plus loin, on pourrait :
+
+- **Calculer des PDR par nœud ou par type de trafic.** Chaque nœud dispose déjà d'un historique de ses transmissions. On peut ainsi déterminer un taux de livraison individuel ou différencié suivant la classe ou le mode d'envoi.
+- **Conserver un historique glissant pour afficher un PDR moyen sur les dernières transmissions.** Le simulateur stocke désormais les vingt derniers événements de chaque nœud et calcule un PDR « récent ».
+- **Ajouter des indicateurs supplémentaires :** PDR par SF, par passerelle et par nœud sont exposés via la méthode `get_metrics()`.
+- **Intégrer des métriques de QoS :** délai moyen et nombre de retransmissions sont suivis pour affiner la vision du réseau.
  

--- a/VERSION_3/launcher/node.py
+++ b/VERSION_3/launcher/node.py
@@ -133,6 +133,24 @@ class Node:
         """Incrémente le compteur de paquets perdus en collision."""
         self.packets_collision += 1
 
+    # ------------------------------------------------------------------
+    # PDR utilities
+    # ------------------------------------------------------------------
+
+    @property
+    def pdr(self) -> float:
+        """Retourne le PDR global de ce nœud."""
+        return self.packets_success / self.packets_sent if self.packets_sent > 0 else 0.0
+
+    @property
+    def recent_pdr(self) -> float:
+        """PDR calculé sur l'historique glissant."""
+        total = len(self.history)
+        if total == 0:
+            return 0.0
+        success = sum(1 for e in self.history if e.get('delivered'))
+        return success / total
+
     def add_energy(self, energy_joules: float):
         """
         Ajoute de l'énergie consommée en transmission.


### PR DESCRIPTION
## Summary
- expose per-node and per-SF delivery metrics
- track recent packet delivery using node history
- document improvement ideas in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d6138c788331a5272ccccbe63e7d