### PR TITLE
Add interference model and adjustable channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Optional node mobility with Bezier interpolation
 - Multi-channel radio support
 - Advanced channel model with loss and noise parameters
+- Capture effect and interference handling with optional power variations
+- Configurable LoRa bandwidth and coding rate
 - Initial spreading factor and power selection
 - Basic LoRaWAN layer with LinkADRReq/LinkADRAns
 

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -56,16 +56,20 @@ aléatoire des fréquences entre les nœuds.
 
 ## Paramètres radio avancés
 
-Le constructeur `Channel` accepte trois options pour modéliser plus finement la
+Le constructeur `Channel` accepte désormais plusieurs options pour affiner la
 réception :
 
 - `cable_loss` : pertes fixes (dB) entre le transceiver et l'antenne.
 - `receiver_noise_floor` : bruit thermique de référence en dBm/Hz (par défaut
   `-174`).
 - `noise_figure` : facteur de bruit du récepteur en dB.
+- `bandwidth` : largeur de bande LoRa (Hz).
+- `coding_rate` : taux de codage (1 pour 4/5 … 4 pour 4/8).
+- `power_variation_std` : écart-type d'une variation aléatoire sur la puissance
+  d'émission.
 
 Ces valeurs influencent le calcul du RSSI et du SNR retournés par
-`Channel.compute_rssi`.
+`Channel.compute_rssi` et la détection de capture.
 
 ## SF et puissance initiaux
 

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -246,6 +246,7 @@ class Simulator:
                     node.channel.capture_threshold_dB,
                     self.current_time,
                     node.channel.frequency_hz,
+                    node.channel,
                 )
             
             # Retenir le meilleur RSSI/SNR mesuré pour cette transmission


### PR DESCRIPTION
## Summary
- support power variations, bandwidth and coding rate in `Channel`
- handle SNR check with interference in `Gateway`
- expose channel instance to `Gateway.start_reception`
- document new radio options in README
- add regression tests for custom channel params and capture effect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d6adcbf4833182cf0418d24d8920