### PR TITLE
Improve simulator event engine performance

### DIFF
--- a/VERSION_3/launcher/node.py
+++ b/VERSION_3/launcher/node.py
@@ -2,6 +2,43 @@
 import math
 
 class Node:
+    __slots__ = (
+        "id",
+        "initial_x",
+        "initial_y",
+        "x",
+        "y",
+        "initial_sf",
+        "sf",
+        "initial_tx_power",
+        "tx_power",
+        "channel",
+        "energy_consumed",
+        "packets_sent",
+        "packets_success",
+        "packets_collision",
+        "speed",
+        "direction",
+        "vx",
+        "vy",
+        "last_move_time",
+        "path",
+        "path_progress",
+        "path_duration",
+        "devaddr",
+        "fcnt_up",
+        "fcnt_down",
+        "class_type",
+        "awaiting_ack",
+        "pending_mac_cmd",
+        "history",
+        "in_transmission",
+        "current_end_time",
+        "last_rssi",
+        "last_snr",
+        "downlink_pending",
+        "acks_received",
+    )
     """
     Représente un nœud IoT (LoRa) dans la simulation, avec suivi complet des métriques de performance.
     


### PR DESCRIPTION
## Summary
- add lightweight `Event` dataclass for heap queue
- convert event queue to store `Event` objects
- optimise event scheduling and popping
- add `__slots__` to `Node` to reduce memory
- update all code to use new event structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d67f5e808331bce47dade1d223ba