### PR TITLE
Add battery capacity tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Advanced channel model with loss and noise parameters
 - Initial spreading factor and power selection
 - Basic LoRaWAN layer with LinkADRReq/LinkADRAns
+- Optional battery model to track remaining energy per node
 
 ## Quick start
 

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -71,6 +71,10 @@ aléatoire des fréquences entre les nœuds.
 
 Le tableau de bord permet maintenant de fixer une **durée réelle maximale** en secondes. Lorsque cette limite est atteinte, la simulation s'arrête automatiquement. Un bouton « Accélérer jusqu'à la fin » lance l'exécution rapide pour obtenir aussitôt les métriques finales.
 
+## Suivi de batterie
+
+Chaque nœud peut être doté d'une capacité d'énergie (en joules) grâce au paramètre `battery_capacity_j` du `Simulator`. La consommation est retranchée de cette réserve et le champ `battery_remaining_j` indique l'autonomie restante.
+
 ## Paramètres radio avancés
 
 Le constructeur `Channel` accepte plusieurs options pour modéliser plus finement la


### PR DESCRIPTION
## Summary
- implement battery capacity for each node
- skip events once a node's battery is depleted
- expose battery info in results
- document new option in READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ddc0acf883318fe96462c6486f8c