### PR TITLE
Improve event scheduling efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Advanced channel model with loss and noise parameters
 - Initial spreading factor and power selection
 - Basic LoRaWAN layer with LinkADRReq/LinkADRAns
+- Optimized event engine supporting large node counts
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- add lightweight `Event` dataclass for the simulator queue
- store log indices to avoid costly scans when finalising events
- streamline queue filtering and scheduling with new event type
- document improved event engine in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ddfdedc0833198186a68eb9d9aaf