### PR TITLE
Add FLoRa energy profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Configurable bandwidth and coding rate per channel
 - Initial spreading factor and power selection
 - Basic LoRaWAN layer with LinkADRReq/LinkADRAns
-- Optional battery model to track remaining energy per node
+- Optional battery model to track remaining energy per node (FLoRa energy profile)
 
 ## Quick start
 

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -73,7 +73,7 @@ Le tableau de bord permet maintenant de fixer une **durée réelle maximale** en
 
 ## Suivi de batterie
 
-Chaque nœud peut être doté d'une capacité d'énergie (en joules) grâce au paramètre `battery_capacity_j` du `Simulator`. La consommation est retranchée de cette réserve et le champ `battery_remaining_j` indique l'autonomie restante.
+Chaque nœud peut être doté d'une capacité d'énergie (en joules) grâce au paramètre `battery_capacity_j` du `Simulator`. La consommation est calculée selon le profil d'énergie FLoRa (courants typiques en veille, réception, etc.) puis retranchée de cette réserve. Le champ `battery_remaining_j` indique l'autonomie restante.
 
 ## Paramètres radio avancés
 

--- a/VERSION_3/launcher/energy_profiles.py
+++ b/VERSION_3/launcher/energy_profiles.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class EnergyProfile:
+    """Energy consumption parameters for a LoRa node."""
+    voltage_v: float = 3.3
+    sleep_current_a: float = 1e-6
+    rx_current_a: float = 11e-3
+    process_current_a: float = 5e-3
+    rx_window_duration: float = 0.1
+
+
+# Default profile based on the FLoRa model (OMNeT++)
+FLORA_PROFILE = EnergyProfile()

--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -7,12 +7,7 @@ try:
 except Exception:  # pragma: no cover - pandas optional
     pd = None
 
-from .node import (
-    Node,
-    RX_CURRENT_A,
-    VOLTAGE_V,
-    RX_WINDOW_DURATION,
-)
+from .node import Node
 from .gateway import Gateway
 from .channel import Channel
 from .multichannel import MultiChannel
@@ -408,10 +403,15 @@ class Simulator:
         
         elif priority == 3:
             # Fenêtre de réception RX1/RX2 pour un nœud
-            node.add_energy(RX_CURRENT_A * VOLTAGE_V * RX_WINDOW_DURATION, "rx")
+            node.add_energy(
+                node.profile.rx_current_a
+                * node.profile.voltage_v
+                * node.profile.rx_window_duration,
+                "rx",
+            )
             if not node.alive:
                 return True
-            node.last_state_time = time + RX_WINDOW_DURATION
+            node.last_state_time = time + node.profile.rx_window_duration
             node.state = "sleep"
             selected_gw = None
             for gw in self.gateways:


### PR DESCRIPTION
## Summary
- use a dataclass for energy profile constants
- default to FLoRa profile for node energy accounting
- compute RX window energy using the node profile
- document the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e217b4bc8331886f2849df6b07ae