### PR TITLE
Fix dashboard path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ source env/bin/activate  # On Windows use env\Scripts\activate
 pip install -r requirements.txt
 
 # Launch the dashboard
-panel serve dashboard.py --show
+panel serve launcher/dashboard.py --show
 
 # Run a simulation
 python run.py --nodes 20 --steps 100

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -13,7 +13,7 @@ Bienvenue ! Ce projet est un **simulateur complet de réseau LoRa**, inspiré du
    ```
 3. **Lancez le tableau de bord :**
    ```bash
-   panel serve dashboard.py --show
+   panel serve launcher/dashboard.py --show
    ```
 4. **Exécutez des simulations en ligne de commande :**
    ```bash


### PR DESCRIPTION
## Summary
- fix incorrect path to dashboard in README
- same fix in VERSION_3 README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853e4d60cbc83319bde419ed7870ae3