### PR TITLE
Fix linter issues

### DIFF
--- a/VERSION_3/launcher/simulator.py
+++ b/VERSION_3/launcher/simulator.py
@@ -1,7 +1,7 @@
 import heapq
 import logging
 import random
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import IntEnum
 
 try:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import random
 
 # Allow importing the VERSION_3 package from the repository root
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,8 +20,6 @@ from VERSION_3.launcher.lorawan import (  # noqa: E402
     LinkCheckAns,
     DeviceTimeReq,
 )
-
-import random
 
 
 def test_channel_compute_rssi_and_airtime():


### PR DESCRIPTION
## Summary
- trim unused import from simulator
- tidy imports in the test module

## Testing
- `ruff check . --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853ed677df083318192ec8d16ab623f