### PR TITLE
Add throughput metric to simulator

### DIFF
--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -128,7 +128,7 @@ L'option `--output` de `run.py` permet d'enregistrer les métriques de la
 simulation dans un fichier CSV. Ce dernier contient l'en‑tête suivant :
 
 ```
-nodes,gateways,area,mode,interval,steps,delivered,collisions,PDR(%),energy,avg_delay
+nodes,gateways,area,mode,interval,steps,delivered,collisions,PDR(%),energy,avg_delay,throughput_bps
 ```
 
 * **nodes** : nombre de nœuds simulés.
@@ -142,6 +142,7 @@ nodes,gateways,area,mode,interval,steps,delivered,collisions,PDR(%),energy,avg_d
 * **PDR(%)** : taux de livraison en pourcentage.
 * **energy** : énergie totale consommée (unités arbitraires).
 * **avg_delay** : délai moyen des paquets livrés.
+* **throughput_bps** : débit binaire moyen des paquets délivrés.
 
 ## Exemple d'analyse
 

--- a/VERSION_3/launcher/dashboard.py
+++ b/VERSION_3/launcher/dashboard.py
@@ -79,6 +79,7 @@ pdr_indicator = pn.indicators.Number(name="PDR", value=0, format="{value:.1%}")
 collisions_indicator = pn.indicators.Number(name="Collisions", value=0, format="{value:d}")
 energy_indicator = pn.indicators.Number(name="Énergie Tx (J)", value=0.0, format="{value:.3f}")
 delay_indicator = pn.indicators.Number(name="Délai moyen (s)", value=0.0, format="{value:.3f}")
+throughput_indicator = pn.indicators.Number(name="Débit (bps)", value=0.0, format="{value:.2f}")
 
 # --- Chronomètre ---
 chrono_indicator = pn.indicators.Number(name="Durée simulation (s)", value=0, format="{value:.1f}")
@@ -168,6 +169,7 @@ def step_simulation():
     collisions_indicator.value = metrics["collisions"]
     energy_indicator.value = metrics["energy_J"]
     delay_indicator.value = metrics["avg_delay_s"]
+    throughput_indicator.value = metrics["throughput_bps"]
     sf_dist = metrics["sf_distribution"]
     sf_fig = go.Figure(data=[go.Bar(x=[f"SF{sf}" for sf in sf_dist.keys()], y=list(sf_dist.values()))])
     sf_fig.update_layout(title="Répartition des SF par nœud", xaxis_title="SF", yaxis_title="Nombre de nœuds")
@@ -356,6 +358,7 @@ def fast_forward(event=None):
                 collisions_indicator.value = metrics["collisions"]
                 energy_indicator.value = metrics["energy_J"]
                 delay_indicator.value = metrics["avg_delay_s"]
+                throughput_indicator.value = metrics["throughput_bps"]
                 sf_dist = metrics["sf_distribution"]
                 sf_fig = go.Figure(data=[go.Bar(x=[f"SF{sf}" for sf in sf_dist.keys()], y=list(sf_dist.values()))])
                 sf_fig.update_layout(
@@ -438,6 +441,7 @@ metrics_col = pn.Column(
     collisions_indicator,
     energy_indicator,
     delay_indicator,
+    throughput_indicator,
 )
 metrics_col.width = 220
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -156,6 +156,13 @@ def test_sim_run_and_step_equivalence():
         pass
     metrics_step = sim_step.get_metrics()
 
-    keys = ["PDR", "collisions", "energy_J", "avg_delay_s", "retransmissions"]
+    keys = [
+        "PDR",
+        "collisions",
+        "energy_J",
+        "avg_delay_s",
+        "retransmissions",
+        "throughput_bps",
+    ]
     for key in keys:
         assert metrics_run[key] == pytest.approx(metrics_step[key])


### PR DESCRIPTION
## Summary
- store `payload_size_bytes` in `Simulator`
- calculate airtime with new payload size
- expose simulation throughput via `get_metrics`
- show throughput in the dashboard
- test throughput consistency
- document throughput in the CSV header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f27f6b188331adc08b1af87a64de