### PR TITLE
Implement full LoRaWAN ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Advanced channel model with loss and noise parameters
 - Configurable bandwidth and coding rate per channel
 - Initial spreading factor and power selection
-- Basic LoRaWAN layer with LinkADRReq/LinkADRAns
+- Full LoRaWAN ADR layer (LinkADRReq/LinkADRAns, ADRACKReq, channel mask and NbTrans)
 - Optional battery model to track remaining energy per node (FLoRa energy profile)
 
 ## Quick start

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -111,10 +111,10 @@ Une couche LoRaWAN simplifiée est maintenant disponible. Le module
 `RX1` et `RX2`. Les nœuds possèdent des compteurs de trames et les passerelles
 peuvent mettre en file d'attente des downlinks via `NetworkServer.send_downlink`.
 
-Depuis cette version, les commandes `LinkADRReq`/`LinkADRAns` sont gérées afin
-d'ajuster le Spreading Factor et la puissance d'émission selon la spécification
-LoRaWAN. Le serveur encode la requête et le nœud y répond automatiquement lors
-du prochain uplink.
+Depuis cette version, la gestion ADR suit la spécification LoRaWAN : en plus des
+commandes `LinkADRReq`/`LinkADRAns`, les bits `ADRACKReq` et `ADR` sont pris en
+charge, le `ChMask` et le `NbTrans` peuvent être ajustés et les compteurs
+`adr_ack_cnt` sont respectés.
 
 Lancer l'exemple minimal :
 


### PR DESCRIPTION
## Summary
- extend ADR state in `Node`
- set ADR/ADRACKReq bits on uplink
- parse channel mask and NbTrans in `LinkADRReq`
- support ADR parameters when sending downlink
- document full ADR support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685457d8cf988331a02999dc7f5318ac