### PR TITLE
Add complete ADR handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Advanced channel model with loss and noise parameters
 - Configurable bandwidth and coding rate per channel
 - Initial spreading factor and power selection
-- Full LoRaWAN ADR layer (LinkADRReq/LinkADRAns, ADRACKReq, channel mask and NbTrans)
+- Full LoRaWAN ADR layer including ADR_ACK_DELAY fallback, ADRACKReq handling, channel mask and NbTrans
 - Optional battery model to track remaining energy per node (FLoRa energy profile)
 
 ## Quick start

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -113,8 +113,9 @@ peuvent mettre en file d'attente des downlinks via `NetworkServer.send_downlink`
 
 Depuis cette version, la gestion ADR suit la spécification LoRaWAN : en plus des
 commandes `LinkADRReq`/`LinkADRAns`, les bits `ADRACKReq` et `ADR` sont pris en
-charge, le `ChMask` et le `NbTrans` peuvent être ajustés et les compteurs
-`adr_ack_cnt` sont respectés.
+charge, le `ChMask` et le `NbTrans` influencent réellement les transmissions,
+le compteur `adr_ack_cnt` respecte le délai `ADR_ACK_DELAY` et le serveur
+répond automatiquement lorsqu'un équipement sollicite `ADRACKReq`.
 
 Lancer l'exemple minimal :
 

--- a/VERSION_3/launcher/multichannel.py
+++ b/VERSION_3/launcher/multichannel.py
@@ -27,3 +27,16 @@ class MultiChannel:
         ch = self.channels[self._rr_index % len(self.channels)]
         self._rr_index += 1
         return ch
+
+    def select_mask(self, mask: int) -> Channel:
+        """Return a channel allowed by the ``mask`` (bit field)."""
+        allowed = [
+            ch for idx, ch in enumerate(self.channels) if mask & (1 << idx)
+        ]
+        if not allowed:
+            return self.select()
+        if self.method == "random":
+            return random.choice(allowed)
+        ch = allowed[self._rr_index % len(allowed)]
+        self._rr_index += 1
+        return ch

--- a/VERSION_3/launcher/server.py
+++ b/VERSION_3/launcher/server.py
@@ -85,6 +85,12 @@ class NetworkServer:
         self.packets_received += 1
         logger.debug(f"NetworkServer: packet event {event_id} from node {node_id} received via gateway {gateway_id}.")
 
+        node = next((n for n in self.nodes if n.id == node_id), None)
+        if node and node.last_adr_ack_req:
+            # Device requested an ADR acknowledgement
+            self.send_downlink(node)
+            node.last_adr_ack_req = False
+
         # Appliquer ADR complet au niveau serveur
         if self.adr_enabled and rssi is not None:
             from .lorawan import SF_TO_DR, DBM_TO_TX_POWER_INDEX, TX_POWER_INDEX_TO_DBM


### PR DESCRIPTION
## Summary
- implement ADR_ACK_DELAY fallback and ADRACKReq tracking in `Node`
- react to ADRACKReq and schedule downlinks in `NetworkServer`
- honor channel mask and `NbTrans` values in `Simulator`
- expose channel mask selection in `MultiChannel`
- document new ADR behavior in README files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545be8f33483318434710627bb91dd