### PR TITLE
Update ADR documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Advanced channel model with loss and noise parameters
 - Configurable bandwidth and coding rate per channel
 - Initial spreading factor and power selection
-- Full LoRaWAN ADR layer including ADR_ACK_DELAY fallback, ADRACKReq handling, channel mask and NbTrans
+- Full LoRaWAN ADR layer following the official specification (LinkADRReq/Ans,
+  ADRACKReq, channel mask, NbTrans, ADR_ACK_DELAY fallback) and derived from the
+  FLoRa model
 - Optional battery model to track remaining energy per node (FLoRa energy profile)
 
 ## Quick start

--- a/VERSION_3/README.md
+++ b/VERSION_3/README.md
@@ -115,7 +115,9 @@ Depuis cette version, la gestion ADR suit la spécification LoRaWAN : en plus d
 commandes `LinkADRReq`/`LinkADRAns`, les bits `ADRACKReq` et `ADR` sont pris en
 charge, le `ChMask` et le `NbTrans` influencent réellement les transmissions,
 le compteur `adr_ack_cnt` respecte le délai `ADR_ACK_DELAY` et le serveur
-répond automatiquement lorsqu'un équipement sollicite `ADRACKReq`.
+répond automatiquement lorsqu'un équipement sollicite `ADRACKReq`. Cette
+implémentation est complète et directement inspirée du modèle FLoRa,
+adaptée ici sous une forme plus légère sans OMNeT++.
 
 Lancer l'exemple minimal :
 


### PR DESCRIPTION
## Summary
- clarify compliance to the LoRaWAN ADR spec in README
- mention FLoRa origin and completeness in VERSION_3 docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685460a3c2e48331807d07649db45b7c